### PR TITLE
Format ignore files examples as valid JSON

### DIFF
--- a/Docs/ignoring-files.md
+++ b/Docs/ignoring-files.md
@@ -12,40 +12,50 @@ If this is something you need in your project, Imgbot offers an ignore option.
 Ignoring by extension
 
 ```
-"ignoredFiles": [
-    "*.jpeg"
-]
+{
+    "ignoredFiles": [
+        "*.jpeg"
+    ]
+}
 ```
 
 Ignoring all images in a specific folder
 
 ```
-"ignoredFiles": [
-    "public/special_images/*"
-]
+{
+    "ignoredFiles": [
+        "public/special_images/*"
+    ]
+}
 ```
 
 Ignoring individual image files
 
 ```
-"ignoredFiles": [
-    "special-image1.png",
-    "other-image1.png"
-]
+{
+    "ignoredFiles": [
+        "special-image1.png",
+        "other-image1.png"
+    ]
+}
 ```
 
 Ignoring nested folders
 
 ```
-"ignoredFiles": [
-    "**/test_images/**"
-]
+{
+    "ignoredFiles": [
+        "**/test_images/**"
+    ]
+}
 ```
 
 Ignoring paths that start with a pattern
 
 ```
-"ignoredFiles": [
-    "path/to/prefix*"
-]
+{
+    "ignoredFiles": [
+        "path/to/prefix*"
+    ]
+}
 ```


### PR DESCRIPTION
I propose formatting the ignore files examples as valid JSON since that is what is done on all other pages. Also, I came to this page from Google and was not aware of the `.imgbotconfig` file being a JSON file, so being explicit about it will probably save some debugging.